### PR TITLE
Adding ant tasks to generate i18n .json files from .lang files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,30 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                      <phase>process-resources</phase>
+                      <configuration>
+                          <target>
+                            <copy todir="${project.build.outputDirectory}">
+                                <fileset dir="${project.build.outputDirectory}"/>
+                                <globmapper from="*.lang" to="*.json"/>
+                            </copy>                        
+                            <replaceregexp replace="" flags="gs" byline="false"
+                                match="/\\*\\*(.*)\\*/">
+                                <fileset dir="${project.build.outputDirectory}" includes="**/i18n/*.json" />
+                            </replaceregexp>
+                          </target>
+                      </configuration>
+                      <goals>
+                          <goal>run</goal>
+                      </goals>
+                    </execution>
+                </executions>
+              </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
datatables-plugin distribution does not include ```.json``` files for the i18n plugin. ```.lang``` files included in the distribution are invalid JSON responses because they include comments. This PR generate .json files (similar to the files available in the datatables CDN for i18n) from ```.lang``` files.